### PR TITLE
[add] ART-Pi v1.2.1

### DIFF
--- a/Board_Support_Packages/STMicroelectronics/STM32H750-RT-ART-Pi/index.json
+++ b/Board_Support_Packages/STMicroelectronics/STM32H750-RT-ART-Pi/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/RT-Thread-Studio/sdk-bsp-stm32h750-realthread-artpi.git",
     "releases": [
         {
+            "version": "1.2.1",
+            "date": "2021-05-21",
+            "description": "released v1.2.1",
+            "size": "328 MB",
+            "url": "https://github.com/RT-Thread-Studio/sdk-bsp-stm32h750-realthread-artpi/archive/1.2.1.zip"
+        },
+        {
             "version": "1.2.0",
             "date": "2021-04-20",
             "description": "released v1.2.0",


### PR DESCRIPTION
修复一下问题：
1. led 例程里面包含了一个软件包，这个应该移除
2. 修复 lora 工程创建失败的问题