### PR TITLE
Add OpenOCD-HPMicro to index.json in Debugger_Support_Packages folder

### DIFF
--- a/Debugger/index.json
+++ b/Debugger/index.json
@@ -9,5 +9,6 @@
         "OpenOCD-KENDRYTE",
         "WCH-LINK_Debugger",
         "OpenOCD-Nuvoton"
+        "OpenOCD-HPMicro"
     ]
 }


### PR DESCRIPTION
Signed-off-by: Fan Yang <fan.yang@hpmicro.com>