### PR TITLE
Improve CI validation and prompting

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -28,6 +28,7 @@ jobs:
         - name: Install Python Tools
           shell: bash
           run: |
+            sudo apt-get update
             sudo apt-get install python3-pip python3-setuptools python3-wheel -y
             pip install requests wheel jsonschema
 

--- a/tools/main.py
+++ b/tools/main.py
@@ -116,8 +116,13 @@ class StudioSdkManagerIndex:
                 new_csp_list.append(url)
         logging.debug(new_csp_list)
 
-        result = list(set(new_csp_list).difference(set(last_csp_list)))
-        return result
+        deleted_list = list(set(last_csp_list).difference(new_csp_list))
+        if len(deleted_list) != 0:
+            logging.info("Please do not delete the old release: "+str(deleted_list))
+            exit(0)
+
+        incleased_list = list(set(new_csp_list).difference(set(last_csp_list)))
+        return incleased_list
 
     @staticmethod
     def csp_to_test(csp_result):


### PR DESCRIPTION
Check whether the index submitted in the PR has deleted the old release version, if so, exit CI and give a prompt