### PR TITLE
Added HPM6750EVKMINI BSP v0.2.1

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini.git",
     "releases": [
         {
+            "version": "0.2.1",
+            "date": "2022-02-18",
+            "description": "Integrated SDK v0.2.1, supported ethernet, added 4 examples",
+            "size": "70 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini/archive/v0.2.1.zip"
+        },
+        {
             "version": "0.2.0",
             "date": "2022-01-30",
             "description": "released v0.2.0",


### PR DESCRIPTION
- Supported both Template and Examples
- Integrated SDK v0.7.1
- Provided Ethernet demo, RW007_WIFI demo, LittleVGL demo
- Switched defualt linker to FLASH XIP linker

Signed-off-by: Fan YANG <fan.yang@hpmicro.com>