### PR TITLE
Upgrade HPM6750EVKMINI RTT BSP to v0.3.0

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
@@ -6,9 +6,16 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini.git",
     "releases": [
         {
+            "version": "0.3.0",
+            "date": "2022-03-16",
+            "description": "Integrated SDK v0.8.0, support sdcard, usb-hid, serial_v2, pwm, flashdb",
+            "size": "120 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini/archive/v0.3.0.zip"
+        },
+        {
             "version": "0.2.1",
             "date": "2022-02-18",
-            "description": "Integrated SDK v0.2.1, supported ethernet, added 4 examples",
+            "description": "Integrated SDK v0.7.1, supported ethernet, added 4 examples",
             "size": "70 MB",
             "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini/archive/v0.2.1.zip"
         },


### PR DESCRIPTION
- Removed the old V0.1.0 and V0.2.0
- Added V0.3.0 release package

Signed-off-by: Fan YANG <fan.yang@hpmicro.com>