### PR TITLE
Upgrade the hpm6750evkmini bsp to v0.4.1

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini.git",
     "releases": [
         {
+            "version": "0.4.1",
+            "date": "2022-04-27",
+            "description": "bug fix for 0.4.0",
+            "size": "121 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini/archive/v0.4.1.zip"
+        },
+        {
             "version": "0.4.0",
             "date": "2022-04-11",
             "description": "Integrated SDK v0.9.0, supported hwtimer,watchdog",


### PR DESCRIPTION
- Fixed bugs in uart_dma_demo, rw007_wifi and FPU context switch

Signed-off-by: Fan YANG <fan.yang@hpmicro.com>