### PR TITLE
[BSP] support wch-link and dependent packages for ch32v103r-evt

### DIFF
--- a/Board_Support_Packages/WCH/sdk-bsp-ch32v103r-evt/index.json
+++ b/Board_Support_Packages/WCH/sdk-bsp-ch32v103r-evt/index.json
@@ -6,11 +6,18 @@
     "repository": "https://github.com/blta/sdk-bsp-ch32v103r-evt.git",
     "releases": [
         {
+            "version": "1.0.1",
+            "date": "2022-05-01",
+            "description": "support WCH-Link",
+            "size": "16 MB",
+            "url": "https://github.com/blta/sdk-bsp-ch32v103r-evt/archive/refs/tags/v1.0.1.zip"
+        },
+        {
             "version": "1.0.0",
             "date": "2022-04-07",
             "description": "released v1.0.0",
-            "size": "11 MB",
+            "size": "36 MB",
             "url": "https://github.com/blta/sdk-bsp-ch32v103r-evt/archive/refs/tags/1.0.0.zip"
-        }       
+        }
     ]
 }


### PR DESCRIPTION
release ch32v103r-evt v1.0.1 :
- support WCH-Link
- support load dependent WCH-GCC and WCH-Link packages automatically
- only hold one template project with rtt v4.1.0
