### PR TITLE
add Nuclei risc-v gcc and openocd tools

### DIFF
--- a/Debugger/OpenOCD-Nuclei/index.json
+++ b/Debugger/OpenOCD-Nuclei/index.json
@@ -1,0 +1,13 @@
+{
+    "name": "OpenOCD-Nuclei",
+    "vendor": "NuClei",
+    "description": "OpenOCD-Nuclei Debugger only for NuClei series",
+    "license": "",
+    "releases": [{
+        "version": "2022.04",
+        "date": "2022-05-04",
+        "description": "Nuclei released 2022.04 version",
+        "size": "3.9 MB",
+        "url": "https://codeload.github.com/riscv-mcu/riscv-openocd/zip/refs/tags/2022.04"
+    }]
+}

--- a/Debugger/index.json
+++ b/Debugger/index.json
@@ -9,6 +9,7 @@
         "OpenOCD-KENDRYTE",
         "WCH-LINK_Debugger",
         "OpenOCD-Nuvoton",
-        "OpenOCD-HPMicro"
+        "OpenOCD-HPMicro",
+        "OpenOCD-Nuclei"
     ]
 }

--- a/Tool_Chain/RISC-V-GCC-NUCLEI/index.json
+++ b/Tool_Chain/RISC-V-GCC-NUCLEI/index.json
@@ -1,0 +1,15 @@
+{
+    "name": "RISC-V-GCC-NUCLEI",
+    "vendor": "NUCLEI",
+    "description": "RISC-V-GCC Tool Chain only for NUCLEI",
+    "license": "",
+    "releases": [
+        {
+            "version": "2022.04",
+            "date": "2022-05-04",
+            "description": "Nuclei released 2022.04 version",
+            "size": "1.9 MB",
+            "url": "https://codeload.github.com/riscv-mcu/riscv-gnu-toolchain/zip/refs/tags/2022.04"
+        }
+    ]
+}

--- a/Tool_Chain/index.json
+++ b/Tool_Chain/index.json
@@ -6,6 +6,7 @@
         "RISC-V-GCC",
         "ARM-LINUX-MUSLEABI",
         "RISC-V-GCC-WCH",
-        "RISC-V-GCC-KENDRYTE"
+        "RISC-V-GCC-KENDRYTE",
+        "RISC-V-GCC-NUCLEI"
     ]
 }


### PR DESCRIPTION
add latest Nuclei risc-v gcc 2022.04
add latest Nuclei openocd 2022.04