### PR TITLE
[fix] update the url link for nuclei tools

### DIFF
--- a/Debugger/OpenOCD-Nuclei/index.json
+++ b/Debugger/OpenOCD-Nuclei/index.json
@@ -5,6 +5,13 @@
     "license": "",
     "releases": [
         {
+            "version": "2022.05",
+            "date": "2022-05-07",
+            "description": "It is 2022.04 version still,prebuilt version",
+            "size": "3.4 MB",
+            "url": "https://github.com/blta/sdk-debugger-openocd-nuclei/archive/2022.04.zip"
+        },
+        {
             "version": "2022.04",
             "date": "2022-05-04",
             "description": "Nuclei released 2022.04 version",

--- a/Tool_Chain/RISC-V-GCC-NUCLEI/index.json
+++ b/Tool_Chain/RISC-V-GCC-NUCLEI/index.json
@@ -5,6 +5,13 @@
     "license": "",
     "releases": [
         {
+            "version": "2022.05",
+            "date": "2022-05-06",
+            "description": "It is 2022.04 version still,prebuilt version",
+            "size": "281 MB",
+            "url": "https://github.com/blta/sdk-toolchain-risc-v-gcc-nuclei/archive/2022.04.zip"
+        },
+        {
             "version": "2022.04",
             "date": "2022-05-04",
             "description": "Nuclei released 2022.04 version",


### PR DESCRIPTION
use prebuilt tools from Nuclei official website
https://www.nucleisys.com/download.php