### PR TITLE
add GD32VF103V-GD-EVAL sdk-bsp

### DIFF
--- a/Board_Support_Packages/GigaDevice/GD32VF103V-GD-EVAL/index.json
+++ b/Board_Support_Packages/GigaDevice/GD32VF103V-GD-EVAL/index.json
@@ -1,0 +1,16 @@
+{
+    "name": "GD32VF103V-GD-EVAL",
+    "vendor": "Blta",
+    "description": "GD32VF103V-GD-EVAL Board Support Packages",
+    "license": "",
+    "repository": "https://github.com/blta/sdk-bsp-gd32vf103v-eval.git",
+    "releases": [
+        {
+            "version": "1.0.0",
+            "date": "2022-05-10",
+            "description": "v1.0.0 release",
+            "size": "24.6 MB",
+            "url": "https://github.com/blta/sdk-bsp-gd32vf103v-eval/archive/v1.0.0.zip"
+        }
+    ]
+}

--- a/Board_Support_Packages/GigaDevice/index.json
+++ b/Board_Support_Packages/GigaDevice/index.json
@@ -6,6 +6,7 @@
         "GD32F103C-GD-EVAL",
         "GD32F303Z-GD-EVAL",
         "GD32F450Z-GD-EVAL",
+        "GD32VF103V-GD-EVAL",
         "GD32VF103-NUCLEI-RVSTAR"
     ]
 }


### PR DESCRIPTION
- use Nuclei GCC
- support GD-LINK with Nuclei OpenOCD

known issue: cann't load the dependent packages