### PR TITLE
Add the RISCV-GCC toolchain for RV32 series

### DIFF
--- a/Tool_Chain/RISC-V-GCC-RV32/index.json
+++ b/Tool_Chain/RISC-V-GCC-RV32/index.json
@@ -1,0 +1,15 @@
+{
+    "name": "RISC-V-GCC-RV32",
+    "vendor": "RISC-V",
+    "description": "RISC-V-GCC Tool Chain for RV32",
+    "license": "",
+    "releases": [
+        {
+            "version": "2022-04-12",
+            "date": "2022-07-04",
+            "description": "RISC-V GCC 11.1.0 for RV32, built on 2022/04/12",
+            "size": "107 MB",
+            "url": "https://github.com/helloeagleyang/riscv32-gnu-toolchain-win/archive/2022.04.12.zip"
+        }
+    ]
+}

--- a/Tool_Chain/index.json
+++ b/Tool_Chain/index.json
@@ -7,6 +7,7 @@
         "ARM-LINUX-MUSLEABI",
         "RISC-V-GCC-WCH",
         "RISC-V-GCC-KENDRYTE",
-        "RISC-V-GCC-NUCLEI"
+        "RISC-V-GCC-NUCLEI",
+        "RISC-V-GCC-RV32"
     ]
 }


### PR DESCRIPTION
- Added RISC-GCC toolchain for RV32 series, the RV64 ARCH was not
  supported

Signed-off-by: Fan YANG <fan.yang@hpmicro.com>