### PR TITLE
Add Geehy APM32F4 support for BSP,CSP,DSP.

### DIFF
--- a/Board_Support_Packages/Geehy/APM32F407IG-GEEHY-MINI/index.json
+++ b/Board_Support_Packages/Geehy/APM32F407IG-GEEHY-MINI/index.json
@@ -1,0 +1,16 @@
+{
+    "name": "APM32F407IG-GEEHY-MINI",
+    "vendor": "Geehy",
+    "description": "APM32F407IG-GEEHY-MINI Board Support Packages",
+    "license": "",
+    "repository": "https://github.com/Aligagago/sdk-bsp-apm32f407ig-geehy-mini.git",
+    "releases": [
+        {
+            "version": "1.0.0",
+            "date": "2022-07-29",
+            "description": "v1.0.0 release",
+            "size": "5 MB",
+            "url": "https://github.com/Aligagago/sdk-bsp-apm32f407ig-geehy-mini/archive/refs/tags/v1.0.0.zip"
+        }
+    ]
+}

--- a/Board_Support_Packages/Geehy/index.json
+++ b/Board_Support_Packages/Geehy/index.json
@@ -3,6 +3,7 @@
     "dvendor": "Geehy",
     "description": "Geehy Board Support Packages",
     "index": [
-        "APM32F103ZE-GEEHY-MINI"
+        "APM32F103ZE-GEEHY-MINI",
+        "APM32F407IG-GEEHY-MINI"
     ]
 }

--- a/Chip_Support_Packages/Geehy/APM32F4/index.json
+++ b/Chip_Support_Packages/Geehy/APM32F4/index.json
@@ -1,0 +1,16 @@
+{
+    "name": "APM32F4",
+    "vendor": "Geehy",
+    "description": "APM32F4 Chip Support Packages",
+    "license": "",
+    "repository": "https://github.com/Aligagago/sdk-csp-apm32f4.git",
+    "releases": [
+        {
+            "version": "1.0.0",
+            "date": "2022-07-29",
+            "description": "released v1.0.0",
+            "size": "24 MB",
+            "url": "https://github.com/Aligagago/sdk-csp-apm32f4/archive/refs/tags/v1.0.0.zip"
+        }
+    ]
+}

--- a/Chip_Support_Packages/Geehy/index.json
+++ b/Chip_Support_Packages/Geehy/index.json
@@ -3,6 +3,7 @@
     "dvendor": "Geehy",
     "description": "APM32 series Chip Support Packages",
     "index": [
-        "APM32F1"
+        "APM32F1",
+        "APM32F4"
     ]
 }

--- a/Debugger/PyOCD/index.json
+++ b/Debugger/PyOCD/index.json
@@ -5,6 +5,13 @@
     "license": "",
     "releases": [
         {
+            "version": "0.1.6",
+            "date": "2022-07-29",
+            "description": "Add geehy apm32f4 support",
+            "size": "96.6 MB",
+            "url": "https://github.com/RT-Thread-Studio/sdk-debugger-pyocd/archive/0.1.6.zip"
+        },
+        {
             "version": "0.1.4",
             "date": "2022-05-06",
             "description": "add geehy apm32f1 support, update pyocd to 0.33.1",


### PR DESCRIPTION
Add Geehy APM32F4 support for BSP,CSP,DSP.