### PR TITLE
Bumped the RT-Thread BSP for HPM6750EVKMINI to v1.0.0

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini.git",
     "releases": [
         {
+            "version": "1.0.0",
+            "date": "2023-01-10",
+            "description": "integrated hpm_sdk_v1.0.0, added support for JLink Probe, added audio demo, bugfix and feature improvements",
+            "size": "97 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini/archive/v1.0.0.zip"
+        },
+        {
             "version": "0.7.0",
             "date": "2022-08-01",
             "description": "integrated hpm_sdk_v0.12.1, added i2c driver, usb_host_msc_udisk, bugfix and feature improvements",


### PR DESCRIPTION
- Integrated HPM SDK v1.0.0
- Added support for JLink Probe
- Added Audio example

Signed-off-by: Fan YANG <fan.yang@hpmicro.com>
