### PR TITLE
Upgrade RTT BSP for HPM6750EVK to v1.0.0

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evk.git",
     "releases": [
         {
+            "version": "1.0.0",
+            "date": "2023-01-28",
+            "description": "Integrated hpm_sdk v1.0.0, added audio demo, added support for JLink Probe, bugfixes and improvements",
+            "size": "98 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evk/archive/v1.0.0.zip"
+        },
+        {
             "version": "0.7.0",
             "date": "2022-08-01",
             "description": "Integrated hpm_sdk v0.12.1, added i2c example, usb_host_msc_udisk, bugfixes and improvements",


### PR DESCRIPTION
- Integrated HPM SDK V1.0.0
- Upgraded RT-Thread to V4.1.0
- Added audio demo
- Added Support for JLink Probe

Signed-off-by: Fan YANG <fan.yang@hpmicro.com>
