### PR TITLE
Add RTT BSP v1.1.0 for HPM6750EVK2

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK2/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK2/index.json
@@ -1,0 +1,16 @@
+{
+    "name": "HPM6750-HPMicro-EVK2",
+    "vendor": "HPMicro",
+    "description": "HPM6750EVK2 Board Support Packages",
+    "license": "",
+    "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evk2.git",
+    "releases": [
+        {
+            "version": "1.1.0",
+            "date": "2023-05-12",
+            "description": "integrated hpm_sdk_v1.1.0",
+            "size": "97 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evk2/archive/v1.1.0.zip"
+        }
+    ]
+}

--- a/Board_Support_Packages/HPMicro/index.json
+++ b/Board_Support_Packages/HPMicro/index.json
@@ -5,6 +5,7 @@
     "index": [
         "HPM6750-HPMicro-EVKMINI",
         "HPM6750-HPMicro-EVK",
-        "HPM6300-HPMicro-EVK"
+        "HPM6300-HPMicro-EVK",
+        "HPM6750-HPMicro-EVK2"
     ]
 }


### PR DESCRIPTION
- Added RTT BSP v1.1.0 for HPM6750EVK2

## 注意

### 阅读确认之后请删除本段内容

1. 提交RT-Thread Studio BSP之前，请先确保提交的内容已经在[RT-Thread主仓库的BSP](https://github.com/RT-Thread/rt-thread/tree/master/bsp)中提交过。请不要在主仓库BSP没有提交/更新的情况下，直接更新RT-Thread Studio的BSP。即RT-Thread Studio BSP不能超前于RT-Thread主仓库BSP，任何bug或者源码更新应当先在主仓库中完成，然后再更新RT-Thread Studio BSP (可以通过 `scons --dist-ide` 一键生成RT-Thread Studio BSP)。

2. 提交RT-Thread Studio BSP前，请确认该BSP在RT-Thread主仓库BSP中可以正确执行 `scons --dist-ide --project-name=xxx --project-path=xxx` 命令。该命令用于直接导出一份RT-Thread Studio BSP工程。[参见PR](https://github.com/RT-Thread/rt-thread/pull/4245)
