### PR TITLE
Add BSP v1.3.0 for HPM6750EVK2

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK2/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK2/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evk2.git",
     "releases": [
         {
+            "version": "1.3.0",
+            "date": "2023-11-03",
+            "description": "integrated hpm_sdk_v1.3.0, bugfixes and improvements",
+            "size": "74 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evk2/archive/v1.3.0.zip"
+        },
+        {
             "version": "1.2.0",
             "date": "2023-08-12",
             "description": "integrated hpm_sdk_v1.2.0, migrated to RT-Thread v5.0.1, bugfixes and improvements",


### PR DESCRIPTION
- Integrated hpm_sdk v1.3.0
- Bugfixes and improvements in rt-thread driver wrappers
