### PR TITLE
Add BSP v1.3.0 for HPM6750EVKMINI

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini.git",
     "releases": [
         {
+            "version": "1.3.0",
+            "date": "2023-11-03",
+            "description": "integrated hpm_sdk_v1.3.0, bugfix and feature improvements",
+            "size": "98 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini/archive/v1.3.0.zip"
+        },
+        {
             "version": "1.2.0",
             "date": "2023-08-12",
             "description": "integrated hpm_sdk_v1.2.0, migrated to rt-thread v5.0.1, bugfix and feature improvements",


### PR DESCRIPTION
- Integrated hpm_sdk v1.3.0
- Bugfixes and improvements in rt-thread driver wrappers

