### PR TITLE
Update sdk-bsp-numaker-hmi-ma35d1 to v1.0.5

### DIFF
--- a/Board_Support_Packages/Nuvoton/NUMAKER-HMI-MA35D1/index.json
+++ b/Board_Support_Packages/Nuvoton/NUMAKER-HMI-MA35D1/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/wosayttn/sdk-bsp-numaker-hmi-ma35d1.git",
     "releases": [
         {
+            "version": "1.0.5",
+            "date": "2023-11-13",
+            "description": "Update debugging function",
+            "size": "69 MB",
+            "url": "https://github.com/wosayttn/sdk-bsp-numaker-hmi-ma35d1/archive/v1.0.5.zip"
+        },
+        {
             "version": "1.0.4",
             "date": "2022-12-27",
             "description": "UART flush",


### PR DESCRIPTION
1. Support AARCH32 debugging function.
2. Update drivers.