### PR TITLE
RT-Thread BSP v1.4.0 for HPM6750EVKMINI

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
@@ -1,10 +1,17 @@
 {
-    "name": "HPM6750-HPMicro-EVKMINI",
+    "name": "HPM6750EVKMINI",
     "vendor": "HPMicro",
     "description": "HPM6750EVKMINI Board Support Packages",
     "license": "",
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini.git",
     "releases": [
+        {
+            "version": "1.4.0",
+            "date": "2024-01-29",
+            "description": "integrated hpm_sdk_v1.4.0, migrated to rt-thread v5.0.2, bugfixes and driver updates, added new examples",
+            "size": "84 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini/archive/v1.4.0.zip"
+        },
         {
             "version": "1.3.0",
             "date": "2023-11-03",


### PR DESCRIPTION
- integrated hpm_sdk 1.4.0
- migrated to rt-thread v5.0.2
- bugfixes and driver updates
- added new examples
