### PR TITLE
RT-Thread BSP v1.4.0 for HPM6750EVK

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK/index.json
@@ -1,10 +1,17 @@
 {
-    "name": "HPM6750-HPMicro-EVK",
+    "name": "HPM6750EVK",
     "vendor": "HPMicro",
     "description": "HPM6750EVK Board Support Packages",
     "license": "",
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evk.git",
     "releases": [
+        {
+            "version": "1.4.0",
+            "date": "2024-01-29",
+            "description": "Integrated hpm_sdk v1.4.0, migrated to rt-thread v5.0.2, bugfixes and driver updates, added new examples",
+            "size": "98 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evk/archive/v1.4.0.zip"
+        },
         {
             "version": "1.3.0",
             "date": "2023-11-03",


### PR DESCRIPTION
- integrated hpm_sdk v1.4.0
- migrated to rt-thread v5.0.2
- bugfixes and driver updates
- added new examples

