### PR TITLE
RT-Thread BSP v1.4.0 for HPM5300EVK

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM5300-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM5300-HPMicro-EVK/index.json
@@ -1,10 +1,17 @@
 {
-    "name": "HPM5300-HPMicro-EVK",
+    "name": "HPM5300EVK",
     "vendor": "HPMicro",
     "description": "HPM5300EVK Board Support Packages",
     "license": "",
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm5300evk.git",
     "releases": [
+        {
+            "version": "1.4.0",
+            "date": "2024-01-29",
+            "description": "Integrated hpm_sdk v1.4.0, migrated to rt-thread v5.0.2, bugfixes and driver updates",
+            "size": "40 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm5300evk/archive/v1.4.0.zip"
+        },
         {
             "version": "1.3.0",
             "date": "2023-11-03",


### PR DESCRIPTION
- integrated hpm_sdk v1.4.0
- migrated rt-thread v5.0.2
- bugfixes and driver updates
