### PR TITLE
RT-Thread BSP v1.5.0 for HPM6750EVK2

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK2/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK2/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evk2.git",
     "releases": [
         {
+            "version": "1.5.0",
+            "date": "2024-04-29",
+            "description": "RT-Thread BSP v1.5.0 for HPM6750EVK2",
+            "size": "115 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evk2/archive/v1.5.0.zip"
+        },        
+        {
             "version": "1.4.1",
             "date": "2024-02-06",
             "description": "Bugfix for BSP v1.4.0",


### PR DESCRIPTION
- integrated hpm_sdk v1.5.0
- added dual-port ethernet support
- added systemview component
- added support for preemptive & vectored interrupt support
- optmized drivers
