### PR TITLE
RT-Thread BSP v1.5.0 for HPM6750EVK

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evk.git",
     "releases": [
         {
+            "version": "1.5.0",
+            "date": "2024-04-29",
+            "description": "RT-Thread BSP v1.5.0 for HPM6750EVK",
+            "size": "145 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evk/archive/v1.5.0.zip"
+        },
+        {
             "version": "1.4.1",
             "date": "2024-02-06",
             "description": "Bugfix for BSP v1.4.0",


### PR DESCRIPTION
- integrated hpm_sdk v1.5.0
- added support for systemview
- optimized drivers
- added dual-port ethernet support
- added support for preemptive & vectored interrupt support

