### PR TITLE
RT-Thread BSP v1.5.0 for HPM6750EVKMINI

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini.git",
     "releases": [
         {
+            "version": "1.5.0",
+            "date": "2024-04-29",
+            "description": "RT-Thread BSP v1.5.0 for HPM6750EVKMINI",
+            "size": "136 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini/archive/v1.5.0.zip"
+        },
+        {
             "version": "1.4.1",
             "date": "2024-02-06",
             "description": "Bugfix for BSP v1.4.0",


### PR DESCRIPTION
- integrated hpm_sdk v1.5.0
- optimized drivers
- added support for systemview
- added support for preemptive & vectored interrupt mode

