### PR TITLE
RT-Thread BSP v1.5.0 for HPM5300EVK

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM5300-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM5300-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm5300evk.git",
     "releases": [
         {
+            "version": "1.5.0",
+            "date": "2024-04-29",
+            "description": "RT-Thread BSP v1.5.0 for HPM5300EVK",
+            "size": "87 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm5300evk/archive/v1.5.0.zip"
+        },
+        {
             "version": "1.4.1",
             "date": "2024-02-06",
             "description": "Bugfix for BSP v1.4.0",


### PR DESCRIPTION
- integrated hpm_sdk v1.5.0
- added systemview component
- added support for preemptive & vectored interrupt
- optimized drivers
- switched usb stack to cherryusb

