### PR TITLE
RT-Thread BSP v1.5.0 for HPM5301EVKLITE

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM5301-HPMicro-EVKLITE/index.json
+++ b/Board_Support_Packages/HPMicro/HPM5301-HPMicro-EVKLITE/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm5301evklite.git",
     "releases": [
         {
+            "version": "1.5.0",
+            "date": "2024-04-29",
+            "description": "RT-Thread BSP v1.5.0 for HPM5301EVKLITE",
+            "size": "80 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm5301evklite/archive/v1.5.0.zip"
+        },
+        {
             "version": "1.4.1",
             "date": "2024-02-06",
             "description": "Bugfix for BSP v1.4.0",


### PR DESCRIPTION
- integrated hpm_sdk v1.5.0
- added systemview component
- added support for preemptive & vectored interrupt
- optimized drivers
- switched usb stack to cherryusb
