### PR TITLE
[BSP][HPM6200EVK] upgrade bsp to v1.6.0

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6200-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6200-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6200evk.git",
     "releases": [
         {
+            "version": "1.6.0",
+            "date": "2024-07-25",
+            "description": "RT-Thread BSP v1.6.0 for HPM6200EVK",
+            "size": "64 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6200evk/archive/v1.6.0.zip"
+        },
+        {
             "version": "1.5.0",
             "date": "2024-04-29",
             "description": "RT-Thread BSP v1.5.0 for HPM6200EVK",


### PR DESCRIPTION
- integrated hpm_sdk v1.6.0
- added usb_host_nic demo

