### PR TITLE
[BSP][HPM5300EVK] upgrade bsp to v1.6.0

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM5300-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM5300-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm5300evk.git",
     "releases": [
         {
+            "version": "1.6.0",
+            "date": "2024-07-25",
+            "description": "RT-Thread BSP v1.6.0 for HPM5300EVK",
+            "size": "55 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm5300evk/archive/v1.6.0.zip"
+        },
+        {
             "version": "1.5.0",
             "date": "2024-04-29",
             "description": "RT-Thread BSP v1.5.0 for HPM5300EVK",


### PR DESCRIPTION
- integrated hpm_sdk v1.6.0
- upgraded cherryusb to v1.3.1
- added USB desc for full-speed
- adapted RT-Thread cache framework
- fixed memory leakage issue in uart_v2 driver

