### PR TITLE
[BSP][HPM5301EVKLITE] upgrade bsp to v1.6.0

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM5301-HPMicro-EVKLITE/index.json
+++ b/Board_Support_Packages/HPMicro/HPM5301-HPMicro-EVKLITE/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm5301evklite.git",
     "releases": [
         {
+            "version": "1.6.0",
+            "date": "2024-07-25",
+            "description": "RT-Thread BSP v1.6.0 for HPM5301EVKLITE",
+            "size": "48 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm5301evklite/archive/v1.6.0.zip"
+        },
+        {
             "version": "1.5.0",
             "date": "2024-04-29",
             "description": "RT-Thread BSP v1.5.0 for HPM5301EVKLITE",


### PR DESCRIPTION
- integrated hpm_sdk v1.6.0
- fixed memory leakage issue in uart_v2 driver
- adapted RT-Thread cache framekwork
- upgraded cherryusb to v1.3.1
- added the USB descriptor for full-speed
