### PR TITLE
[BSP][HPM6800EVK] upgrade bsp to v1.6.0

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM6800-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6800-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6800evk.git",
     "releases": [
         {
+            "version": "1.6.0",
+            "date": "2024-07-25",
+            "description": "Rt-Thread BSP v1.6.0 for HPM6800EVK",
+            "size": "100 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6800evk/archive/v1.6.0.zip"
+        },
+        {
             "version": "1.5.0",
             "date": "2024-04-29",
             "description": "Rt-Thread BSP v1.5.0 for HPM6800EVK",


### PR DESCRIPTION
- integrated hpm_sdk v1.6.0
- added airoc_wifi_demo
- upgraded cherryusb to v1.3.1
- bugfix & improvements in drivers

