### PR TITLE
Feature/upgrade hpm bsp to v1.9.0

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM5300-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM5300-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm5300evk.git",
     "releases": [
         {
+            "version": "1.9.0",
+            "date": "2025-04-23",
+            "description": "RT-Thread BSP v1.9.0 for HPM5300EVK",
+            "size": "59 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm5300evk/archive/v1.9.0.zip"
+        },
+        {
             "version": "1.6.0",
             "date": "2024-07-25",
             "description": "RT-Thread BSP v1.6.0 for HPM5300EVK",

--- a/Board_Support_Packages/HPMicro/HPM5301-HPMicro-EVKLITE/index.json
+++ b/Board_Support_Packages/HPMicro/HPM5301-HPMicro-EVKLITE/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm5301evklite.git",
     "releases": [
         {
+            "version": "1.9.0",
+            "date": "2025-04-23",
+            "description": "RT-Thread BSP v1.9.0 for HPM5301EVKLITE",
+            "size": "53 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm5301evklite/archive/v1.9.0.zip"
+        },
+        {
             "version": "1.6.0",
             "date": "2024-07-25",
             "description": "RT-Thread BSP v1.6.0 for HPM5301EVKLITE",

--- a/Board_Support_Packages/HPMicro/HPM6200-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6200-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6200evk.git",
     "releases": [
         {
+            "version": "1.9.0",
+            "date": "2025-04-23",
+            "description": "RT-Thread BSP v1.9.0 for HPM6200EVK",
+            "size": "73 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6200evk/archive/v1.9.0.zip"
+        },
+        {
             "version": "1.6.0",
             "date": "2024-07-25",
             "description": "RT-Thread BSP v1.6.0 for HPM6200EVK",

--- a/Board_Support_Packages/HPMicro/HPM6300-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6300-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6300evk.git",
     "releases": [
         {
+            "version": "1.9.0",
+            "date": "2025-04-23",
+            "description": "RT-Thread BSP v1.9.0 for HPM6300EVK",
+            "size": "80 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6300evk/archive/v1.9.0.zip"
+        },
+        {
             "version": "1.6.0",
             "date": "2024-07-25",
             "description": "RT-Thread BSP v1.6.0 for HPM6300EVK",

--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK2/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK2/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evk2.git",
     "releases": [
         {
+            "version": "1.9.0",
+            "date": "2025-04-23",
+            "description": "RT-Thread BSP v1.9.0 for HPM6750EVK2",
+            "size": "110 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evk2/archive/v1.9.0.zip"
+        },
+        {
             "version": "1.6.0",
             "date": "2024-07-25",
             "description": "RT-Thread BSP v1.6.0 for HPM6750EVK2",

--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini.git",
     "releases": [
         {
+            "version": "1.9.0",
+            "date": "2025-04-23",
+            "description": "RT-Thread BSP v1.9.0 for HPM6750EVKMINI",
+            "size": "130 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini/archive/v1.9.0.zip"
+        },
+        {
             "version": "1.6.0",
             "date": "2024-07-25",
             "description": "RT-Thread BSP v1.6.0 for HPM6750EVKMINI",

--- a/Board_Support_Packages/HPMicro/HPM6800-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6800-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6800evk.git",
     "releases": [
         {
+            "version": "1.9.0",
+            "date": "2025-04-23",
+            "description": "Rt-Thread BSP v1.9.0 for HPM6800EVK",
+            "size": "110 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6800evk/archive/v1.9.0.zip"
+        },
+        {
             "version": "1.6.0",
             "date": "2024-07-25",
             "description": "Rt-Thread BSP v1.6.0 for HPM6800EVK",

--- a/Board_Support_Packages/HPMicro/HPM6E00-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6E00-HPMicro-EVK/index.json
@@ -3,8 +3,15 @@
     "vendor": "HPMicro",
     "description": "HPM6E00EVK Board Support Packages",
     "license": "",
-    "repository": "https://github.com/hpmicro/rtt-bsp-hpm6800evk.git",
+    "repository": "https://github.com/hpmicro/rtt-bsp-hpm6e00evk.git",
     "releases": [
+        {
+            "version": "1.9.0",
+            "date": "2025-04-23",
+            "description": "Rt-Thread BSP v1.9.0 for HPM6E00EVK",
+            "size": "85 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6e00evk/archive/v1.9.0.zip"
+        },
         {
             "version": "1.6.0",
             "date": "2024-07-25",

--- a/Board_Support_Packages/HPMicro/HPM6P00-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6P00-HPMicro-EVK/index.json
@@ -1,0 +1,16 @@
+{
+    "name": "HPM6P00EVK",
+    "vendor": "HPMicro",
+    "description": "HPM6P00EVK Board Support Packages",
+    "license": "",
+    "repository": "https://github.com/hpmicro/rtt-bsp-hpm6p00evk.git",
+    "releases": [
+        {
+            "version": "1.9.0",
+            "date": "2025-04-23",
+            "description": "Rt-Thread BSP v1.9.0 for HPM6P00EVK",
+            "size": "60 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6p00evk/archive/v1.9.0.zip"
+        }
+    ]
+}

--- a/Board_Support_Packages/HPMicro/index.json
+++ b/Board_Support_Packages/HPMicro/index.json
@@ -11,6 +11,7 @@
         "HPM5300-HPMicro-EVK",
         "HPM5301-HPMicro-EVKLITE",
         "HPM6800-HPMicro-EVK",
-        "HPM6E00-HPMicro-EVK"
+        "HPM6E00-HPMicro-EVK",
+        "HPM6P00-HPMicro-EVK"
     ]
 }


### PR DESCRIPTION
Upgrade RT-Thread BSP v1.9.0 for:
- HPM6750EVK2
- HPM6750EVKMINI
- HPM6300EVK
- HPM5300EVK
- HPM5301EVKLITE
- HPM6800EVK
- HPM6E00EVK

Added RT-Thread BSP v1.9.0 for:
- HPM6P00EVK