### PR TITLE
Ci update index

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -61,7 +61,7 @@ jobs:
           shell: bash
           env:
             GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-          if: ${{ github.repository == 'RT-Thread-Studio/sdk-index' && github.ref == 'refs/heads/master' && github.event_name == 'push' }} 
+          if: ${{ github.event_name == 'push' }} 
           run: |
             echo ${{ github.repository }}
             cd ${{ github.workspace }}/scripts

--- a/scripts/sdk_index_gen.py
+++ b/scripts/sdk_index_gen.py
@@ -55,20 +55,21 @@ def packages_info_mirror_register(packages_json_file):
 
             if url.startswith('https://github.com/'):
                 if url.endswith('.git'):
-                    tmp = url.split('/')
-                    repo = tmp[4]
-                    replace_url = "https://gitee.com/RT-Thread-Studio-Mirror" + '/' + repo
+                    #tmp = url.split('/')
+                    #repo = tmp[4]
+                    #replace_url = "https://gitee.com/RT-Thread-Studio-Mirror" + '/' + repo
+                    replace_url = url.replace('https://github.com', 'http://git-mirror.rt-thread.com:12236')
                     item['url'] = replace_url
 
-                    if url == "https://github.com/RT-Thread/rt-thread.git":
-                        item['url'] = "https://gitee.com/rtthread/rt-thread.git"
+                    #if url == "https://github.com/RT-Thread/rt-thread.git":
+                    #    item['url'] = "https://gitee.com/rtthread/rt-thread.git"
                 else:
-                    new_zip_url = url.replace('https://github.com', 'https://gitee.com')
-                    tmp = new_zip_url.split('/')
-                    tmp[3] = "RT-Thread-Studio-Mirror"
-                    tmp[5] = 'repository/archive'
-                    file_replace_url = '/'.join(tmp)
-                    item['url'] = file_replace_url
+                    new_zip_url = url.replace('https://github.com', 'http://git-mirror.rt-thread.com:12236')
+                    #tmp = new_zip_url.split('/')
+                    #tmp[3] = "RT-Thread-Studio-Mirror"
+                    #tmp[5] = 'repository/archive'
+                    #file_replace_url = '/'.join(tmp)
+                    item['url'] = new_zip_url
 
         payload_register = {
             "packages": [{}]


### PR DESCRIPTION
## 注意

### 阅读确认之后请删除本段内容

1. 提交RT-Thread Studio BSP之前，请先确保提交的内容已经在[RT-Thread主仓库的BSP](https://github.com/RT-Thread/rt-thread/tree/master/bsp)中提交过。请不要在主仓库BSP没有提交/更新的情况下，直接更新RT-Thread Studio的BSP。即RT-Thread Studio BSP不能超前于RT-Thread主仓库BSP，任何bug或者源码更新应当先在主仓库中完成，然后再更新RT-Thread Studio BSP (可以通过 `scons --dist-ide` 一键生成RT-Thread Studio BSP)。

2. 提交RT-Thread Studio BSP前，请确认该BSP在RT-Thread主仓库BSP中可以正确执行 `scons --dist-ide --project-name=xxx --project-path=xxx` 命令。该命令用于直接导出一份RT-Thread Studio BSP工程。[参见PR](https://github.com/RT-Thread/rt-thread/pull/4245)
