### PR TITLE
RT-Threadd BSP v1.10.0 for HPMicro EVK boards

### DIFF
--- a/Board_Support_Packages/HPMicro/HPM5300-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM5300-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm5300evk.git",
     "releases": [
         {
+            "version": "1.10.0",
+            "date": "2025-08-26",
+            "description": "RT-Thread BSP v1.10.0 for HPM5300EVK",
+            "size": "98 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm5300evk/archive/v1.10.0.zip"
+        },
+        {
             "version": "1.9.0",
             "date": "2025-04-23",
             "description": "RT-Thread BSP v1.9.0 for HPM5300EVK",

--- a/Board_Support_Packages/HPMicro/HPM5301-HPMicro-EVKLITE/index.json
+++ b/Board_Support_Packages/HPMicro/HPM5301-HPMicro-EVKLITE/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm5301evklite.git",
     "releases": [
         {
+            "version": "1.10.0",
+            "date": "2025-08-26",
+            "description": "RT-Thread BSP v1.10.0 for HPM5301EVKLITE",
+            "size": "93 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm5301evklite/archive/v1.10.0.zip"
+        },
+        {
             "version": "1.9.0",
             "date": "2025-04-23",
             "description": "RT-Thread BSP v1.9.0 for HPM5301EVKLITE",

--- a/Board_Support_Packages/HPMicro/HPM5E00-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM5E00-HPMicro-EVK/index.json
@@ -1,0 +1,16 @@
+{
+    "name": "HPM5E00EVK",
+    "vendor": "HPMicro",
+    "description": "HPM5E00EVK Board Support Packages",
+    "license": "",
+    "repository": "https://github.com/hpmicro/rtt-bsp-hpm5e00evk.git",
+    "releases": [
+        {
+            "version": "1.10.0",
+            "date": "2025-08-26",
+            "description": "Rt-Thread BSP v1.10.0 for HPM5E00EVK",
+            "size": "98 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm5e00evk/archive/v1.10.0.zip"
+        }
+    ]
+}

--- a/Board_Support_Packages/HPMicro/HPM6200-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6200-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6200evk.git",
     "releases": [
         {
+            "version": "1.10.0",
+            "date": "2025-08-26",
+            "description": "RT-Thread BSP v1.10.0 for HPM6200EVK",
+            "size": "129 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6200evk/archive/v1.10.0.zip"
+        },
+        {
             "version": "1.9.0",
             "date": "2025-04-23",
             "description": "RT-Thread BSP v1.9.0 for HPM6200EVK",

--- a/Board_Support_Packages/HPMicro/HPM6300-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6300-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6300evk.git",
     "releases": [
         {
+            "version": "1.10.0",
+            "date": "2025-08-26",
+            "description": "RT-Thread BSP v1.10.0 for HPM6300EVK",
+            "size": "118 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6300evk/archive/v1.10.0.zip"
+        },
+        {
             "version": "1.9.0",
             "date": "2025-04-23",
             "description": "RT-Thread BSP v1.9.0 for HPM6300EVK",

--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK2/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVK2/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evk2.git",
     "releases": [
         {
+            "version": "1.10.0",
+            "date": "2025-08-26",
+            "description": "RT-Thread BSP v1.10.0 for HPM6750EVK2",
+            "size": "147 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evk2/archive/v1.10.0.zip"
+        },
+        {
             "version": "1.9.0",
             "date": "2025-04-23",
             "description": "RT-Thread BSP v1.9.0 for HPM6750EVK2",

--- a/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6750-HPMicro-EVKMINI/index.json
@@ -5,6 +5,13 @@
     "license": "",
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini.git",
     "releases": [
+         {
+            "version": "1.10.0",
+            "date": "2025-08-26",
+            "description": "RT-Thread BSP v1.10.0 for HPM6750EVKMINI",
+            "size": "168 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6750evkmini/archive/v1.10.0.zip"
+        },
         {
             "version": "1.9.0",
             "date": "2025-04-23",

--- a/Board_Support_Packages/HPMicro/HPM6800-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6800-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6800evk.git",
     "releases": [
         {
+            "version": "1.10.0",
+            "date": "2025-08-26",
+            "description": "RT-Thread BSP v1.10.0 for HPM6800EVK",
+            "size": "147 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6800evk/archive/v1.10.0.zip"
+        },
+        {
             "version": "1.9.0",
             "date": "2025-04-23",
             "description": "Rt-Thread BSP v1.9.0 for HPM6800EVK",

--- a/Board_Support_Packages/HPMicro/HPM6E00-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6E00-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6e00evk.git",
     "releases": [
         {
+            "version": "1.10.0",
+            "date": "2025-08-26",
+            "description": "Rt-Thread BSP v1.10.0 for HPM6E00EVK",
+            "size": "126 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6e00evk/archive/v1.10.0.zip"
+        },
+        {
             "version": "1.9.0",
             "date": "2025-04-23",
             "description": "Rt-Thread BSP v1.9.0 for HPM6E00EVK",

--- a/Board_Support_Packages/HPMicro/HPM6P00-HPMicro-EVK/index.json
+++ b/Board_Support_Packages/HPMicro/HPM6P00-HPMicro-EVK/index.json
@@ -6,6 +6,13 @@
     "repository": "https://github.com/hpmicro/rtt-bsp-hpm6p00evk.git",
     "releases": [
         {
+            "version": "1.10.0",
+            "date": "2025-08-26",
+            "description": "Rt-Thread BSP v1.10.0 for HPM6P00EVK",
+            "size": "99 MB",
+            "url": "https://github.com/hpmicro/rtt-bsp-hpm6p00evk/archive/v1.10.0.zip"
+        },
+        {
             "version": "1.9.0",
             "date": "2025-04-23",
             "description": "Rt-Thread BSP v1.9.0 for HPM6P00EVK",

--- a/Board_Support_Packages/HPMicro/index.json
+++ b/Board_Support_Packages/HPMicro/index.json
@@ -12,6 +12,7 @@
         "HPM5301-HPMicro-EVKLITE",
         "HPM6800-HPMicro-EVK",
         "HPM6E00-HPMicro-EVK",
-        "HPM6P00-HPMicro-EVK"
+        "HPM6P00-HPMicro-EVK",
+        "HPM5E00-HPMicro-EVK"
     ]
 }


### PR DESCRIPTION
- added support for HPM5E00EVK
- upgraded BSP to v1.10.0
