### PR TITLE
Add NUMAKER-CM3034HS8 BSP package

### DIFF
--- a/Board_Support_Packages/Nuvoton/NUMAKER-CM3034HS8/index.json
+++ b/Board_Support_Packages/Nuvoton/NUMAKER-CM3034HS8/index.json
@@ -1,0 +1,16 @@
+{
+    "name": "NUMAKER-CM3034HS8",
+    "vendor": "Nuvoton",
+    "description": "NUMAKER-CM3034HS8 Board Support Packages",
+    "license": "",
+    "repository": "https://github.com/OpenNuvoton/sdk-bsp-numaker-cm3034hs8.git",
+    "releases": [
+        {
+            "version": "1.0.0",
+            "date": "2026-07-02",
+            "description": "released v1.0.0",
+            "size": "116 MB",
+            "url": "https://github.com/OpenNuvoton/sdk-bsp-numaker-cm3034hs8/archive/v1.0.0.zip"
+        }
+    ]
+}

--- a/Board_Support_Packages/Nuvoton/index.json
+++ b/Board_Support_Packages/Nuvoton/index.json
@@ -18,6 +18,7 @@
         "NK-980IOTG2D",
         "NUMAKER-HMI-MA35H0",
         "NUMAKER-IOT-MA35D0",
+        "NUMAKER-CM3034HS8",
         "NUMAKER-M2L31KI",
         "NK-980IOTG1D",
         "NUMAKER-M55M1",


### PR DESCRIPTION
Add Nuvoton NUMAKER-CM3034HS8 RT-Thread Studio BSP package.

The CM3034HS8 board is compatible with the existing M3334KI BSP except for chip PDID.
The BSP has been validated on NuMaker-CM3034HS8 hardware.

Release tag: v1.0.0
Repository: https://github.com/OpenNuvoton/sdk-bsp-numaker-cm3034hs8